### PR TITLE
Upgraded dependencies

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: equatable_lint_example
 description: Package with every examples for the equatable_lint package
-version: 0.1.2
+version: 0.1.3
 
 publish_to: none
 
@@ -12,6 +12,6 @@ dependencies:
   equatable: ^2.0.5
 
 dev_dependencies:
-  custom_lint: ^0.2.12
+  custom_lint: ^0.4.0
   equatable_lint:
     path: ../

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   analyzer: ^5.12.0
   analyzer_plugin: ^0.11.2
-  collection: ^1.17.2
+  collection: ^1.17.1
   custom_lint_builder: ^0.4.0
   equatable: ^2.0.5
   source_gen: ^1.3.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: equatable_lint
-version: 0.2.2
+version: 0.2.3
 description: This is a set of rules to make classes using Equatable more maintainable. We make sure here that every fields in an Equatable class is linked to the Equatable props getter.
 homepage: https://github.com/bamlab/equatable_lint
 repository: https://github.com/bamlab/equatable_lint

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: equatable_lint
-version: 0.2.1
+version: 0.2.2
 description: This is a set of rules to make classes using Equatable more maintainable. We make sure here that every fields in an Equatable class is linked to the Equatable props getter.
 homepage: https://github.com/bamlab/equatable_lint
 repository: https://github.com/bamlab/equatable_lint
@@ -8,9 +8,9 @@ environment:
   sdk: ">=2.19.0 <3.0.0"
 
 dependencies:
-  analyzer: ^5.4.0
+  analyzer: ^5.12.0
   analyzer_plugin: ^0.11.2
-  collection: ^1.16.0
-  custom_lint_builder: ^0.2.12
+  collection: ^1.17.2
+  custom_lint_builder: ^0.4.0
   equatable: ^2.0.5
-  source_gen: ^1.2.7
+  source_gen: ^1.3.2


### PR DESCRIPTION
## Description

When using equatable_lint with Dart 3.0, it forces the custom_lint 0.2.12, which, somehow, forces builder to be in a pre Dart 3 mode (meaning: every builder (example: Isar generator) doesn't accept any Dart 3 syntax, such as `final class`, `switch` expressions, etc.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [X] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

The only thing changed was upgrading dependencies for the latest version possible.